### PR TITLE
NXP-21383: put Nuxeo Agenda MP back to integration

### DIFF
--- a/marketplace.ini
+++ b/marketplace.ini
@@ -10,6 +10,8 @@ skipTests = False
 skipITs = False
 auto_increment_policy = auto_patch
 
+[marketplace-agenda]
+
 [marketplace-amazon-s3]
 
 [marketplace-api-playground]


### PR DESCRIPTION
Revert commit 17ac30f 'NXP-20899: disconnect agenda addon before 8.10 release'