### PR TITLE
NXBT-2605: remove GitSCM.PerBuildTag

### DIFF
--- a/Jenkinsfiles/IT-release-on-demand-packages.groovy
+++ b/Jenkinsfiles/IT-release-on-demand-packages.groovy
@@ -46,7 +46,6 @@ timestamps {
                             browser: [$class: 'GithubWeb', repoUrl: 'https://github.com/nuxeo/nuxeo'],
                             extensions: [
                                     [$class: 'RelativeTargetDirectory', relativeTargetDir: 'nuxeo'],
-                                    [$class: 'PerBuildTag'],
                                     [$class: 'WipeWorkspace'],
                                     [$class: 'CloneOption', depth: 1, noTags: false, reference: '', shallow: false, timeout: 60],
                                     [$class: 'CheckoutOption', timeout: 60]


### PR DESCRIPTION
`[$class: 'PerBuildTag']` tells Jenkins to generate a tag per build. We don't have a use of such a tag and it conflicts with the branch name auto resolution.

Another complementary fix would be to explicitly pass the branch name, ie store `nuxeo-branch=master`