### PR TITLE
NXP-27912: remove webui as dam dependency and add it reverse order

### DIFF
--- a/marketplace.ini
+++ b/marketplace.ini
@@ -77,17 +77,17 @@ tag = %(nuxeo-tag)s
 
 [marketplace-imap-connector]
 
+[marketplace-dam]
+other_versions = %(nuxeo-snapshot)s/%(nuxeo-tag)s/%(nuxeo-next_snapshot)s
+
 [nuxeo-web-ui]
 mp_to_upload = plugin/web-ui/marketplace/target/*.zip
-
+#depends on marketplace-dam
+other_versions = %(nuxeo-snapshot)s/%(nuxeo-tag)s/%(nuxeo-next_snapshot)s,%(marketplace-dam-snapshot)s/%(marketplace-dam-tag)s/%(marketplace-dam-next_snapshot)s
 
 [marketplace-template-rendering]
 mp_to_upload = package*/target/package-*.zip
 #depends on nuxeo-web-ui for tests
-other_versions = %(nuxeo-snapshot)s/%(nuxeo-tag)s/%(nuxeo-next_snapshot)s,%(nuxeo-web-ui-snapshot)s/%(nuxeo-web-ui-tag)s/%(nuxeo-web-ui-next_snapshot)s
-
-[marketplace-dam]
-#depends on nuxeo-web-ui
 other_versions = %(nuxeo-snapshot)s/%(nuxeo-tag)s/%(nuxeo-next_snapshot)s,%(nuxeo-web-ui-snapshot)s/%(nuxeo-web-ui-tag)s/%(nuxeo-web-ui-next_snapshot)s
 
 [marketplace-groups-rights-audit]


### PR DESCRIPTION
Related to: 
https://github.com/nuxeo/marketplace-dam/pull/16
https://github.com/nuxeo/nuxeo-web-ui/pull/709